### PR TITLE
tracing: remove subscriber init from inside app

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,7 +75,6 @@ futures-timer = "3.0.2"
 crossbeam-channel = "0.5.4"
 rdkafka = { version = "0.28.0", default-features = false, features = ["libz"] }
 tracing = "0.1.34"
-tracing-subscriber = { version = "0.3.11", features = ["env-filter"] }
 url = "2.2.2"
 libc = "0.2.126"
 cuneiform-fields = "0.1.1"

--- a/src/app.rs
+++ b/src/app.rs
@@ -19,7 +19,6 @@ use rdkafka::error::KafkaResult;
 use rdkafka::message::{BorrowedMessage, OwnedMessage};
 use rdkafka::ClientConfig;
 use tracing::{error, info};
-use tracing_subscriber::{self, fmt, EnvFilter};
 use url::Url;
 
 use crate::config::Config;
@@ -532,10 +531,6 @@ where
     }
 
     pub fn run(self) {
-        tracing_subscriber::fmt()
-            .with_env_filter(EnvFilter::from_default_env())
-            .init();
-
         // Load all background workers
         self.background_workers();
 

--- a/src/stores/rocksdb.rs
+++ b/src/stores/rocksdb.rs
@@ -31,7 +31,6 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 use tracing::{info, warn};
-use tracing_subscriber::filter::FilterExt;
 use url::Url;
 
 const DEFAULT_WRITE_BUFFER_SIZE: usize = (1_usize << 6) * 1024 * 1024; // 64 MB

--- a/src/types/agent.rs
+++ b/src/types/agent.rs
@@ -17,7 +17,6 @@ use std::io::Read;
 use std::marker::PhantomData as marker;
 use std::sync::Arc;
 use tracing::{error, info};
-use tracing_subscriber::filter::FilterExt;
 
 ///////////////////////////////////////////////////
 //////// CAgent

--- a/src/types/context.rs
+++ b/src/types/context.rs
@@ -16,7 +16,6 @@ use std::future::Future;
 use std::io::Read;
 use std::sync::Arc;
 use tracing::info;
-use tracing_subscriber::filter::FilterExt;
 
 ///////////////////////////////////////////////////
 //////// Context

--- a/src/types/cronjob.rs
+++ b/src/types/cronjob.rs
@@ -14,7 +14,6 @@ use std::future::Future;
 use std::io::Read;
 use std::sync::Arc;
 use tracing::info;
-use tracing_subscriber::filter::FilterExt;
 
 ///////////////////////////////////////////////////
 //////// CronJob

--- a/src/types/service.rs
+++ b/src/types/service.rs
@@ -17,7 +17,6 @@ use std::future::Future;
 use std::io::Read;
 use std::sync::Arc;
 use tracing::info;
-use tracing_subscriber::filter::FilterExt;
 
 ///
 /// Possible states that services can be in.

--- a/src/types/table.rs
+++ b/src/types/table.rs
@@ -27,7 +27,6 @@ use std::sync::mpsc::channel;
 use std::sync::Arc;
 use std::time::Duration;
 use tracing::{error, info};
-use tracing_subscriber::filter::FilterExt;
 use url::Url;
 
 #[derive(Clone)]

--- a/src/types/table_agent.rs
+++ b/src/types/table_agent.rs
@@ -16,7 +16,6 @@ use std::future::Future;
 use std::io::Read;
 use std::sync::Arc;
 use tracing::{error, info};
-use tracing_subscriber::filter::FilterExt;
 
 pub type Tables<State> = HashMap<String, CTable<State>>;
 

--- a/src/types/task.rs
+++ b/src/types/task.rs
@@ -13,7 +13,6 @@ use std::future::Future;
 use std::io::Read;
 use std::sync::Arc;
 use tracing::{error, info};
-use tracing_subscriber::filter::FilterExt;
 
 ///////////////////////////////////////////////////
 //////// CTask

--- a/src/types/timer.rs
+++ b/src/types/timer.rs
@@ -15,7 +15,6 @@ use std::future::Future;
 use std::io::Read;
 use std::sync::Arc;
 use tracing::{error, info};
-use tracing_subscriber::filter::FilterExt;
 
 ///////////////////////////////////////////////////
 //////// CTimer


### PR DESCRIPTION
Users may be willing to configure their own subscriber globally,
initializing this will conflict with the user provided subscriber,
thus removing it.